### PR TITLE
feat: upgrade node manager with testnet-deploy

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,10 +27,15 @@ inputs:
       version.
   interval:
     description: The interval to apply between each node upgrade. Units are ms. The default is 200.
+  network-name:
+    description: The name of the network to upgrade
+    required: true
   safenode-version:
     description: >
       The safenode version to upgrade to. If not supplied, `testnet-deploy` will use the latest
       version.
+  safenode-manager-version:
+    description: The safenode-manager version to upgrade to
   sn-auditor-version:
     description: >
       The auditor version to upgrade to. If not supplied, `testnet-deploy` will use the latest
@@ -38,8 +43,9 @@ inputs:
   ssh-secret-key:
     description: SSH key that Ansible will use to connect to the node VMs.
     required: true
-  testnet-name:
-    description: SSH key that Ansible will use to connect to the node VMs.
+  target:
+    description: The upgrade target. Valid values are "safenode" or "safenode-manager".
+    default: safenode
     required: true
   testnet-deploy-branch:
     description: >
@@ -99,6 +105,7 @@ runs:
         echo "TERRAFORM_STATE_BUCKET_NAME=${{ env.TERRAFORM_STATE_BUCKET_NAME }}" >> .env
 
     - name: upgrade network
+      if: inputs.target == 'safenode'
       env:
         ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
         AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
@@ -109,7 +116,6 @@ runs:
         # The auditor argument won't be used for now. It is not available on the `upgrade` command
         # yet, and the auditor upgrade could well be a separate command.
         SN_AUDITOR_VERSION: ${{ inputs.sn-auditor-version }}
-        UPLOADER_VM_COUNT: ${{ inputs.uploader-vm-count }}
       shell: bash
       run: |
         set -e
@@ -121,6 +127,23 @@ runs:
         [[ -n $FAUCET_VERSION ]] && command="$command --faucet-version $FAUCET_VERSION "
         [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
         [[ -n $SAFENODE_VERSION ]] && command="$command --safenode-version $SAFENODE_VERSION "
+
+        echo "Will run testnet-deploy with: $command"
+        eval $command
+
+    - name: upgrade node manager
+      if: inputs.target == 'safenode-manager'
+      env:
+        NETWORK_NAME: ${{ inputs.network-name }}
+        SAFENODE_MANAGER_VERSION: ${{ inputs.safenode-manager-version }}
+      shell: bash
+      run: |
+        set -e
+
+        cd sn-testnet-deploy
+
+        command="cargo run -- upgrade-node-manager --name $NETWORK_NAME "
+        [[ -n $SAFENODE_MANAGER_VERSION ]] && command="$command --version $SAFENODE_MANAGER_VERSION "
 
         echo "Will run testnet-deploy with: $command"
         eval $command

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,126 @@
+name: sn-testnet-upgrade-action
+description: Use sn-testnet-deploy to upgrade a network
+inputs:
+  ansible-forks:
+    description: >
+      The number of forks to use with Ansible. A network should be upgraded gradually, so this
+      should be small. The default used by testnet-deploy is 2.
+  ansible-vault-password:
+    description: Password for Ansible vault
+    required: true
+  aws-access-key-id:
+    description: AWS access key ID
+    required: true
+  aws-access-key-secret:
+    description: AWS access key
+    required: true
+  aws-region:
+    description: AWS region
+    default: eu-west-2
+    required: true
+  do-token:
+    description: Digital Ocean Authorization token
+    required: true
+  faucet-version:
+    description: >
+      The faucet version to upgrade to. If not supplied, `testnet-deploy` will use the latest
+      version.
+  interval:
+    description: The interval to apply between each node upgrade. Units are ms. The default is 200.
+  safenode-version:
+    description: >
+      The safenode version to upgrade to. If not supplied, `testnet-deploy` will use the latest
+      version.
+  sn-auditor-version:
+    description: >
+      The auditor version to upgrade to. If not supplied, `testnet-deploy` will use the latest
+      version.
+  ssh-secret-key:
+    description: SSH key that Ansible will use to connect to the node VMs.
+    required: true
+  testnet-name:
+    description: SSH key that Ansible will use to connect to the node VMs.
+    required: true
+  testnet-deploy-branch:
+    description: >
+      The branch for the sn-testnet-deploy repository. Enables using forks to test changes for
+      testnet-deploy.
+    default: main
+  testnet-deploy-user:
+    description: >
+      The user or organisation for the sn-testnet-deploy repository. Enables using forks to test
+      changes for testnet-deploy.
+    default: maidsafe
+
+runs:
+  using: composite
+  steps:
+    - name: install tools
+      shell: bash
+      run: |
+        sudo apt-get update -y
+        # There is some issue with the latest version of Ansible not correctly
+        # reading the Digital Ocean token from environment variables, so just
+        # pin to this version for now.
+        pip install --user ansible==8.2.0
+        pip install --user boto3
+        sudo apt-get install jq -y
+    - name: clone testnet-deploy and set it up for use
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
+        AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-access-key-secret }}
+        DO_PAT: ${{ inputs.do-token }}
+        TERRAFORM_STATE_BUCKET_NAME: maidsafe-org-infra-tfstate
+        TESTNET_DEPLOY_BRANCH: ${{ inputs.testnet-deploy-branch }}
+        TESTNET_DEPLOY_USER: ${{ inputs.testnet-deploy-user }}
+      run: |
+        set -e
+
+        git clone --quiet --single-branch --depth 1 \
+          --branch $TESTNET_DEPLOY_BRANCH https://github.com/$TESTNET_DEPLOY_USER/sn-testnet-deploy
+
+        mkdir ~/.ssh
+        echo "${{ inputs.ssh-secret-key }}" >> ~/.ssh/id_rsa
+        chmod 0400 ~/.ssh/id_rsa
+        ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
+
+        mkdir ~/.ansible
+        echo "${{ inputs.ansible-vault-password }}" >> ~/.ansible/vault-password
+
+        cd sn-testnet-deploy
+        echo "ANSIBLE_VAULT_PASSWORD_PATH=/home/runner/.ansible/vault-password" >> .env
+        echo "AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}" >> .env
+        echo "AWS_DEFAULT_REGION=${{ env.AWS_DEFAULT_REGION }}" >> .env
+        echo "AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}" >> .env
+        echo "DO_PAT=${{ env.DO_PAT }}" >> .env
+        echo "SSH_KEY_PATH=/home/runner/.ssh/id_rsa" >> .env
+        echo "TERRAFORM_STATE_BUCKET_NAME=${{ env.TERRAFORM_STATE_BUCKET_NAME }}" >> .env
+
+    - name: upgrade network
+      env:
+        ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
+        AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
+        FAUCET_VERSION: ${{ inputs.faucet-version }}
+        INTERVAL: ${{ inputs.interval }}
+        NETWORK_NAME: ${{ inputs.network-name }}
+        SAFENODE_VERSION: ${{ inputs.safenode-version }}
+        # The auditor argument won't be used for now. It is not available on the `upgrade` command
+        # yet, and the auditor upgrade could well be a separate command.
+        SN_AUDITOR_VERSION: ${{ inputs.sn-auditor-version }}
+        UPLOADER_VM_COUNT: ${{ inputs.uploader-vm-count }}
+      shell: bash
+      run: |
+        set -e
+
+        cd sn-testnet-deploy
+
+        command="cargo run -- upgrade --name $NETWORK_NAME "
+        [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
+        [[ -n $FAUCET_VERSION ]] && command="$command --faucet-version $FAUCET_VERSION "
+        [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
+        [[ -n $SAFENODE_VERSION ]] && command="$command --safenode-version $SAFENODE_VERSION "
+
+        echo "Will run testnet-deploy with: $command"
+        eval $command


### PR DESCRIPTION
- ac488e4 **feat: upgrade a network with testnet-deploy**

  Uses the `testnet-deploy upgrade` command to perform an upgrade to an existing network.

- 9a93bd6 **feat: upgrade node manager with testnet-deploy**

  A new action is provided for upgrading the node manager itself, which can be done as a separate
  thing.

  For each machine in the deployment, `testnet-deploy` will simply overwrite the `safenode-manager`
  binary with a specific version.