### PR TITLE
New Inputs for Ansible Verbosity and Custom Inventory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,8 @@ inputs:
   ansible-vault-password:
     description: Password for Ansible vault
     required: true
+  ansible-verbose:
+    description: Set to true to run Ansible with its most verbose output
   aws-access-key-id:
     description: AWS access key ID
     required: true
@@ -108,6 +110,7 @@ runs:
       if: inputs.target == 'safenode'
       env:
         ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
+        ANSIBLE_VERBOSE: ${{ inputs.ansible-verbose }}
         AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
         FAUCET_VERSION: ${{ inputs.faucet-version }}
         INTERVAL: ${{ inputs.interval }}
@@ -123,6 +126,7 @@ runs:
         cd sn-testnet-deploy
 
         command="cargo run -- upgrade --name $NETWORK_NAME "
+        [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
         [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
         [[ -n $FAUCET_VERSION ]] && command="$command --faucet-version $FAUCET_VERSION "
         [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: AWS region
     default: eu-west-2
     required: true
+  custom-inventory:
+    description: >
+      Run the upgrade against particular VMs in the environment.
+      Should be a comma-separated list.
   do-token:
     description: Digital Ocean Authorization token
     required: true
@@ -112,6 +116,7 @@ runs:
         ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
         ANSIBLE_VERBOSE: ${{ inputs.ansible-verbose }}
         AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
+        CUSTOM_INVENTORY: ${{ inputs.custom-inventory }}
         FAUCET_VERSION: ${{ inputs.faucet-version }}
         INTERVAL: ${{ inputs.interval }}
         NETWORK_NAME: ${{ inputs.network-name }}
@@ -131,6 +136,13 @@ runs:
         [[ -n $FAUCET_VERSION ]] && command="$command --faucet-version $FAUCET_VERSION "
         [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
         [[ -n $SAFENODE_VERSION ]] && command="$command --safenode-version $SAFENODE_VERSION "
+
+        if [[ -n $CUSTOM_INVENTORY ]]; then
+          IFS=',' read -ra VM_NAMES <<< "$CUSTOM_INVENTORY"
+          for vm_name in "${VM_NAMES[@]}"; do
+            command="$command --custom-inventory $vm_name"
+          done
+        fi
 
         echo "Will run testnet-deploy with: $command"
         eval $command


### PR DESCRIPTION
- 2547505 **feat: provide `ansible-verbose` input**

  The upgrade run is having some trouble with SSH connections. Revealing Ansible's SSH specification
  may help us debug the issue.

- 144a91f **feat: provide `custom-inventory` input**

  Use this input to pass a list of particular VMs for the upgrade to run against. It can be used to
  target VMs that were 'unreachable' in previous runs. It saves time by narrowing the scope of
  machines to run against.

  `testnet-deploy` will look up the IP addresses of the VMs named using the argument, then write
  those IP addresses out to a custom inventory file.